### PR TITLE
Handle finish channel in "runWithoutStatus" mode

### DIFF
--- a/status.go
+++ b/status.go
@@ -138,6 +138,9 @@ func (t *Terminal) runWithoutStatus(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			return
+		case errch := <-t.finish:
+			errch <- nil
+			return
 		case msg := <-t.msg:
 			var err error
 			if w, ok := t.dst.(stringWriter); ok {


### PR DESCRIPTION
Fixes fd0/machma#9. Without this, the program can hang when no TTY is detected.